### PR TITLE
allow Read32FromFile to return signed value

### DIFF
--- a/csrc/pf_save.c
+++ b/csrc/pf_save.c
@@ -513,7 +513,7 @@ error:
 #ifndef PF_NO_FILEIO
 
 /***************************************************************/
-static uint32_t Read32FromFile( FileStream *fid, uint32_t *ValPtr )
+static int32_t Read32FromFile( FileStream *fid, uint32_t *ValPtr )
 {
 	int32_t numr;
 	uint8_t pad[4];


### PR DESCRIPTION
`Read32FromFile()` returns either `-1` or `0`; the result of the call is then compared (`< 0`) with zero to detect possible error. But as the type of the function was unsigned (`uint32_t`), the error is never detected.