### PR TITLE
Fix auto.term in history

### DIFF
--- a/fth/history.fth
+++ b/fth/history.fth
@@ -502,7 +502,7 @@ variable KH-INSIDE        ( true if we are scrolling inside the history buffer )
 ;
 : AUTO.TERM
 	history.off
-	auto.init
+	auto.term
 ;
 
 if.forgotten history.off


### PR DESCRIPTION
It was calling auto.init by mistake.

Signed-off-by: Phil Burk <philburk@mobileer.com>