### PR TITLE
Add Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+os:
+  - linux
+  - osx
+env:
+  - WIDTHOPT=-m64
+  - WIDTHOPT=-m32
+language: c
+compiler:
+  - gcc
+  - clang
+matrix:
+  exclude:
+    - os: osx
+      compiler: gcc # gcc seems to be an symlink to clang
+sudo: true
+before_install: |
+  if [ "$TRAVIS_OS_NAME" = linux -a "$WIDTHOPT" = -m32 ]; then
+     sudo apt-get install -y gcc-multilib
+  fi
+script:  # CC is exported by travis
+  - make WIDTHOPT=$WIDTHOPT -C build/unix/ test


### PR DESCRIPTION
This adds a simple configuration file to build and test pForth in [Travis CI](https://travis-ci.org/).
It runs `make test` with various configurations.

To enable this, you'd have to login at Travis. You can use your GitHub login for that.
Once logged in, you should be able to find your pForth repository, and tell Travis to built it. You'll have to push something to GitHub to start the first build.