### PR TITLE
Fix SAVE-INPUT

### DIFF
--- a/fth/save-input.fth
+++ b/fth/save-input.fth
@@ -1,13 +1,26 @@
 \ SAVE-INPUT and RESTORE-INPUT
+\
+\ This code is part of pForth.
+\
+\ The pForth software code is dedicated to the public domain,
+\ and any third party may reproduce, distribute and modify
+\ the pForth software code or any derivative works thereof
+\ without any compensation or license.  The pForth software
+\ code is provided on an "as is" basis without any warranty
+\ of any kind, including, without limitation, the implied
+\ warranties of merchantability and fitness for a particular
+\ purpose and their equivalents under the laws of any jurisdiction.
 
 anew task-save-input.fth
 
 private{
 
-: save-buffer ( -- column source-id 2 ) >in @ source-id 2 ;
+: SAVE-BUFFER ( -- column source-id 2 ) >in @ source-id 2 ;
 
-: restore-column ( column -- flag )
-    source nip over <
+\ Restore >IN from COLUMN unless COLUMN is too large.  Valid values
+\ for COLUMN are from 0 to (including) the length of SOURCE plus one.
+: RESTORE-COLUMN ( column -- flag )
+    source nip 1+ over u<
     IF   drop  true
     ELSE >in ! false
     THEN
@@ -17,7 +30,7 @@ private{
 \ file SOURCE-ID.  Assume that the current line is stored in SOURCE
 \ and that the current file-position is at an end-of-line (or
 \ end-of-file).
-: line-start-position ( -- ud )
+: LINE-START-POSITION ( -- ud )
     source-id file-position throw
     \ unless at end-of-file, subtract newline
     source-id file-size throw 2over d= 0= IF 1 s>d d- THEN
@@ -25,7 +38,7 @@ private{
     source nip s>d d-
 ;
 
-: save-file ( column line filepos:ud source-id 5 -- )
+: SAVE-FILE ( column line filepos:ud source-id 5 -- )
     >in @
     source-line-number@
     line-start-position
@@ -33,14 +46,14 @@ private{
     5
 ;
 
-: restore-file ( column line filepos:ud -- flag )
-    source-id reposition-file  IF 2drop true exit THEN
-    refill                     0= IF 2drop true exit THEN
+: RESTORE-FILE ( column line filepos:ud -- flag )
+    source-id reposition-file  IF 2drop true EXIT THEN
+    refill                     0= IF 2drop true EXIT THEN
     source-line-number!
     restore-column
 ;
 
-: ndrop ( n*x n -- ) 0 ?do drop loop ;
+: NDROP ( n*x n -- ) 0 ?DO drop LOOP ;
 
 }private
 
@@ -49,21 +62,21 @@ private{
 \ keyboard    >IN  SourceID=(0)   2
 \ file        >IN  lineNumber filePos  SourceID=(fileID) 5
 : SAVE-INPUT ( -- column {line filepos}? source-id n )
-    source-id case
-	-1 of save-buffer endof
-	0  of save-buffer endof
-	drop save-file exit
-    endcase
+    source-id CASE
+	-1 OF save-buffer ENDOF
+	0  OF save-buffer ENDOF
+	drop save-file EXIT
+    ENDCASE
 ;
 
 : RESTORE-INPUT ( column {line filepos}? source-id n -- flag )
-    over source-id <> IF ndrop true exit THEN
+    over source-id <> IF ndrop true EXIT THEN
     drop
-    case
-	-1 of restore-column endof
-	0  of restore-column endof
-	drop restore-file exit
-    endcase
+    CASE
+	-1 OF restore-column ENDOF
+	0  OF restore-column ENDOF
+	drop restore-file EXIT
+    ENDCASE
 ;
 
 privatize


### PR DESCRIPTION
The test in t_file.fth uncovered a problem with RESTORE-COLUMN.  Fix
that.  Also, upcase some things according to style guide.

* fth/save-input.fth (RESTORE-COLUMN): Fix off-by-one bug.