### PR TITLE
Add support for multi-line ( comments

### DIFF
--- a/fth/file.fth
+++ b/fth/file.fth
@@ -61,6 +61,16 @@ create (LINE-TERMINATOR) \n c,
     0 2r> + c!        ( )
 ;
 
+: MULTI-LINE-COMMENT ( "comment<rparen>" -- )
+    BEGIN
+        >in @ ')' parse         ( >in c-addr len )
+        nip + >in @ =           ( delimiter-not-found? )
+    WHILE                       ( )
+        refill 0= IF EXIT THEN  ( )
+    REPEAT
+
+;
+
 }private
 
 \ This treats \n, \r\n, and \r as line terminator.  Reading is done
@@ -107,5 +117,14 @@ create (LINE-TERMINATOR) \n c,
     ELSE throw_rename_file
     THEN
 ;
+
+: (  ( "comment<rparen>"  -- )
+    source-id
+    CASE
+        -1 OF postpone ( ENDOF
+        0  OF postpone ( ENDOF
+        multi-line-comment
+    ENDCASE
+; immediate
 
 privatize

--- a/fth/file.fth
+++ b/fth/file.fth
@@ -68,7 +68,6 @@ create (LINE-TERMINATOR) \n c,
     WHILE                       ( )
         refill 0= IF EXIT THEN  ( )
     REPEAT
-
 ;
 
 }private
@@ -123,6 +122,7 @@ create (LINE-TERMINATOR) \n c,
     CASE
         -1 OF postpone ( ENDOF
         0  OF postpone ( ENDOF
+        \ for input from files
         multi-line-comment
     ENDCASE
 ; immediate

--- a/fth/t_file.fth
+++ b/fth/t_file.fth
@@ -215,12 +215,12 @@ T{ FN2 R/W BIN OPEN-FILE SWAP DROP 0= -> FALSE }T
 T{ FN2 DELETE-FILE 0= -> FALSE }T
 
 \ ----------------------------------------------------------------------------
-\ TESTING multi-line ( comments
-\ 
-\ T{ ( 1 2 3
-\ 4 5 6
-\ 7 8 9 ) 11 22 33 -> 11 22 33 }T
-\ 
+TESTING multi-line ( comments
+
+T{ ( 1 2 3
+4 5 6
+7 8 9 ) 11 22 33 -> 11 22 33 }T
+
 \ ----------------------------------------------------------------------------
 TESTING SOURCE-ID (can only test it does not return 0 or -1)
 


### PR DESCRIPTION
The standard says that in files, ( ... ) comments can span multiple lines.  This patch implements that. I hope that it doesn't create problems with existing code that has "unterminated" comments i.e. a "(" without a the corresponding ")" in before the line ends. 

* fth/file.fth ((): Redefine.
(MULTI-LINE-COMMENT): New helper.

* fth/t_file.fth: Uncomment test for multi line comments.