### PR TITLE
This introduces a RESIZE-FILE-LIMIT

### DIFF
--- a/csrc/pf_io.c
+++ b/csrc/pf_io.c
@@ -230,12 +230,10 @@ cell_t sdRenameFile( const char *OldName, const char *NewName )
     return -1;
 }
 
-ThrowCode sdResizeFile( FileStream * File, ucell_t SizeLo, ucell_t SizeHi )
+ThrowCode sdResizeFile( FileStream * File, uint64_t NewSize )
 {
     UNIMPLEMENTED("sdResizeFile");
-    TOUCH(File);
-    TOUCH(SizeLo);
-    TOUCH(SizeHi);
+    TOUCH(NewSize);
     return THROW_RESIZE_FILE;
 }
 

--- a/csrc/pf_io.h
+++ b/csrc/pf_io.h
@@ -87,7 +87,7 @@ void ioTerm( void );
     cell_t sdSeekFile( FileStream * Stream, off_t Position, int32_t Mode );
     cell_t sdRenameFile( const char *OldName, const char *NewName );
     cell_t sdDeleteFile( const char *FileName );
-    ThrowCode sdResizeFile( FileStream *, ucell_t SizeLo, ucell_t SizeHi );
+    ThrowCode sdResizeFile( FileStream *, uint64_t Size);
     off_t sdTellFile( FileStream * Stream );
     cell_t sdCloseFile( FileStream * Stream );
     cell_t sdInputChar( FileStream *stream );
@@ -140,7 +140,7 @@ void ioTerm( void );
         #define  PF_SEEK_CUR   (SEEK_CUR)
         #define  PF_SEEK_END   (SEEK_END)
 
-        ThrowCode sdResizeFile( FileStream *, ucell_t SizeLo, ucell_t SizeHi );
+        ThrowCode sdResizeFile( FileStream *, uint64_t Size);
 
         /*
         ** printf() is only used for debugging purposes.

--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -260,7 +260,7 @@ PForthDictionary pfBuildDictionary( cell_t HeaderSize, cell_t CodeSize )
     CreateDicEntryC( ID_FILE_REPOSITION, "REPOSITION-FILE",  0 );
     CreateDicEntryC( ID_FILE_FLUSH, "FLUSH-FILE",  0 );
     CreateDicEntryC( ID_FILE_RENAME, "(RENAME-FILE)",  0 );
-    CreateDicEntryC( ID_FILE_RESIZE, "RESIZE-FILE",  0 );
+    CreateDicEntryC( ID_FILE_RESIZE, "(RESIZE-FILE)",  0 );
     CreateDicEntryC( ID_FILE_RO, "R/O",  0 );
     CreateDicEntryC( ID_FILE_RW, "R/W",  0 );
     CreateDicEntryC( ID_FILE_WO, "W/O",  0 );

--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -106,20 +106,12 @@ static bool_t ExtendFile( FileStream *File, size_t Diff )
     return Error;
 }
 
-/* Return non-FALSE if the double-cell unsigned number LO/HI
- * is greater then LONG_MAX.
- */
-static bool_t IsGreaterThanLongMax( ucell_t Lo, ucell_t Hi )
-{
-    return (Hi != 0) || (Lo > LONG_MAX);
-}
-
-ThrowCode sdResizeFile( FileStream *File, ucell_t SizeLo, ucell_t SizeHi )
+ThrowCode sdResizeFile( FileStream *File, uint64_t Size )
 {
     bool_t Error = TRUE;
-    if( !IsGreaterThanLongMax( SizeLo, SizeHi ) )
+    if( Size <= LONG_MAX )
     {
-	long Newsize = (long) SizeLo;
+	long Newsize = (long) Size;
 	if( fseek( File, 0, SEEK_END ) == 0 )
 	{
 	    long Oldsize = ftell( File );

--- a/fth/file.fth
+++ b/fth/file.fth
@@ -117,6 +117,22 @@ create (LINE-TERMINATOR) \n c,
     THEN
 ;
 
+\ A limit used to perform a sanity check on the size argument for
+\ RESIZE-FILE.
+2variable RESIZE-FILE-LIMIT
+10000000 0 resize-file-limit 2!  \ 10MB is somewhat arbitrarily chosen
+
+: RESIZE-FILE ( ud fileid -- ior )
+    -rot 2dup resize-file-limit 2@ d>             ( fileid ud big? )
+    IF
+        ." Argument (" 0 d.r ." ) is larger then RESIZE-FILE-LIMIT." cr
+        ." (You can increase RESIZE-FILE-LIMIT with 2!)" cr
+        abort
+    ELSE
+        rot (resize-file)
+    THEN
+;
+
 : (  ( "comment<rparen>"  -- )
     source-id
     CASE

--- a/fth/system.fth
+++ b/fth/system.fth
@@ -364,6 +364,14 @@
 	rot = -rot = and
 ;
 
+: D< ( d1 d2 -- flag )
+    d- nip 0<
+;
+
+: D> ( d1 d2 -- flag )
+    2swap d<
+;
+
 \ define some useful constants ------------------------------
 1 0= constant FALSE
 0 0= constant TRUE


### PR DESCRIPTION
The intention is to protect the user from a presumably common mistake:
passing the size as single cell number instead of a double cell
number.  This would create a very big file that is written in many
small chunks.

I also changed sdResizeFile to use uint64_t instead of Lo/Hi pairs.

* csrc/pfcompil.c (pfBuildDictionary): Rename RESIZE-FILE
to (RESIZE-FILE).

* fth/file.fth (RESIZE-FILE-LIMIT): New variable.
(RESIZE-FILE): Use it.

* fth/system.fth (D<, D>): Implemented.  Needed for compare the limit.

* csrc/pf_io.h, csrc/pf_io.c (sdResizeFile): Use uint64_t.
* csrc/stdio/pf_fileio_stdio.c (sdResizeFile): Use uint64_t.
(IsGreaterThanLongMax): Deleted.

* csrc/pf_inner.c (ID_FILE_RESIZE): Convert the Lo/Hi pair to uint64_t.
(UdToUint64, UdIsUint64): New helpers.