### PR TITLE
Fixes #52: add an additional dependency to fix the parallel make issue

### DIFF
--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -111,6 +111,7 @@ $(PFORTHAPP): $(PFDICDAT) $(PFEMBOBJS)
 	@echo ""
 	@echo "Standalone pForth executable written to $(PFORTHAPP)"
 
+pf_save.eo: $(PFDICDAT)
 
 # target aliases
 pfdicapp: $(PFDICAPP)


### PR DESCRIPTION
This PR is just a minimal workaround to fix #52, it doesn't fix the problem in the Makefile.

Since the suffix rules don't check the prerequisites, I suggest to use the pattern rule for the `.o` and `.eo` targets.
