### PR TITLE
fixes mixed declarations and code warning

### DIFF
--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -1156,9 +1156,10 @@ cell_t ffRefill( void )
     if( gCurrentTask->td_InputStream == PF_STDIN )
     {
     /* ACCEPT is deferred so we call it through the dictionary. */
+        ThrowCode throwCode;
         PUSH_DATA_STACK( gCurrentTask->td_SourcePtr );
         PUSH_DATA_STACK( TIB_SIZE );
-        ThrowCode throwCode = pfCatch( gAcceptP_XT );
+        throwCode = pfCatch( gAcceptP_XT );
         if (throwCode) {
             Result = throwCode;
             goto error;


### PR DESCRIPTION
../../csrc/pfcompil.c:1161:9: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
 1161 |         ThrowCode throwCode;
      |         ^~~~~~~~~