### PR TITLE
Add PRIVATIZE to history.fth

### DIFF
--- a/fth/history.fth
+++ b/fth/history.fth
@@ -494,6 +494,7 @@ variable KH-INSIDE        ( true if we are scrolling inside the history buffer )
     THEN
 ;
 
+privatize
 
 : AUTO.INIT
     auto.init

--- a/fth/private.fth
+++ b/fth/private.fth
@@ -24,16 +24,20 @@ variable private-stop
 $ 20 constant FLAG_SMUDGE
 
 : PRIVATE{
+    private-start @ 0= not abort" ERROR: Missing PRIVATIZE"
+    private-stop @ 0= not abort" ERROR: Missing PRIVATIZE"
     latest private-start !
     0 private-stop !
 ;
+
 : }PRIVATE
-    private-stop @ 0= not abort" Extra }PRIVATE"
+    private-stop @ 0= not abort" ERROR: Extra }PRIVATE"
     latest private-stop !
 ;
+
 : PRIVATIZE  ( -- , smudge all words between PRIVATE{ and }PRIVATE )
-    private-start @ 0= abort" Missing PRIVATE{"
-    private-stop @ 0= abort" Missing }PRIVATE"
+    private-start @ 0= abort" ERROR: Missing PRIVATE{"
+    private-stop @ 0= abort" ERROR: Missing }PRIVATE"
     private-stop @
     BEGIN
         dup private-start @ u>    \ 19970701


### PR DESCRIPTION
This will hide the internal words for HISTORY.

Also added some error checks to detect when we forget to call PRIVATIZE.

Fixes #54