### PR TITLE
use pattern rules instead of suffix rules in the Makefile

### DIFF
--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -73,10 +73,10 @@ LINK = $(CC) $(LDFLAGS)
 PFOBJS     = $(PFSOURCE:.c=.o)
 PFEMBOBJS  = $(PFSOURCE:.c=.eo)
 
-.c.o: $(PFINCLUDES)
+%.o: %.c $(PFINCLUDES)
 	$(COMPILE) -c -o $@ $<
 
-.c.eo: $(PFINCLUDES) pfdicdat.h
+%.eo: %.c $(PFINCLUDES) pfdicdat.h
 	$(COMPILE) $(EMBCCOPTS) -c -o $@ $<
 
 .PHONY: all clean test


### PR DESCRIPTION
Both the two suffix rules in current Makefile include prerequisites, so a make
with POSIX mode enabled will treat them as rules to build two normal files with
strange names (.c.o and .c.eo), rather than create pattern rules implicitly.

According to the release note from make 4.3, the POSIX behavior will be adopted
as the only behavior in a future release, so use the pattern rules instead.


As I have mentioned in #53 , the use of suffix rules in current Makefile is incorrect.
So the make cannot find any rule to build the target `pf_cglue.o`. This PR should fix #76 .

References:
 - https://lwn.net/Articles/810071/
 - https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html
