### PR TITLE
docs: fix simple typo, complier -> compiler

### DIFF
--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -722,7 +722,7 @@ void ffLiteral( cell_t Num )
 #ifdef PF_SUPPORT_FP
 void ffFPLiteral( PF_FLOAT fnum )
 {
-    /* Hack for Metrowerks complier which won't compile the
+    /* Hack for Metrowerks compiler which won't compile the
      * original expression.
      */
     PF_FLOAT  *temp;


### PR DESCRIPTION
There is a small typo in csrc/pfcompil.c.

Should read `compiler` rather than `complier`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md