### PR TITLE
Add definition of word: 2CONSTANT

### DIFF
--- a/fth/system.fth
+++ b/fth/system.fth
@@ -309,11 +309,6 @@
         DOES> @ ( -- n )
 ;
 
-: 2CONSTANT ( n1 n2 <name> -c- ) ( -x- n1 n2 )
-        CREATE , , ( n1 n2 -- )
-        DOES> 2@   ( -- n1 n2 )
-;
-
 
 
 0 1- constant -1
@@ -326,6 +321,10 @@
         dup cell+ @ swap @
 ;
 
+: 2CONSTANT ( n1 n2 <name> -c- ) ( -x- n1 n2 )
+        CREATE , , ( n1 n2 -- )
+        DOES> 2@   ( -- n1 n2 )
+;
 
 : ABS ( n -- |n| )
         dup 0<

--- a/fth/system.fth
+++ b/fth/system.fth
@@ -309,6 +309,11 @@
         DOES> @ ( -- n )
 ;
 
+: 2CONSTANT ( n1 n2 <name> -c- ) ( -x- n1 n2 )
+        CREATE , , ( n1 n2 -- )
+        DOES> 2@   ( -- n1 n2 )
+;
+
 
 
 0 1- constant -1


### PR DESCRIPTION
Adds definition of `2CONSTANT`, a standard ANS Forth word. I've tried my best to ensure it's correct and that the comments are accurate, but I'm not an experienced Forther.

Relevant documentation:

* https://www.complang.tuwien.ac.at/forth/ansforth-cvs/documents/html3/double/TwoCONSTANT.html
* https://forth-standard.org/standard/rationale#rat:double:2CONSTANT