### PR TITLE
Make sure terminal output is unbuffered on POSIX systems (probably related to musl, and not glibc)

### DIFF
--- a/csrc/posix/pf_io_posix.c
+++ b/csrc/posix/pf_io_posix.c
@@ -131,6 +131,10 @@ void sdTerminalInit(void)
         {
             perror("sdTerminalInit: tcsetattr");
         }
+        if (setvbuf(stdout, NULL, _IONBF, (size_t) 0) != 0)
+        {
+            perror("sdTerminalInit: setvbuf");
+        }
     }
 }
 


### PR DESCRIPTION
Call `setvbuf` on terminal initialization in `csrc/posix/pf_io_posix.c`. At least on one platform (OpenWRT), pForth was buffering the characters while the user typed, instead of echoing them immediately; this fixes that issue.

Question: I did not check the output of `setvbuf`. Do you think it's necessary? I could change it so it issues a warning (to `stderr`, so the output is flushed immediately! :grin: )