### PR TITLE
Implement getopt() in Unix/Linux

### DIFF
--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -28,7 +28,6 @@ FULL_WARNINGS =  \
         -fsigned-char \
         -fno-builtin \
         -fno-unroll-loops \
-        -fno-keep-inline-functions \
         -pedantic \
         -Wcast-qual \
         -Wall \

--- a/csrc/pf_main.c
+++ b/csrc/pf_main.c
@@ -26,10 +26,13 @@
 #if (defined(PF_NO_STDIO) || defined(PF_EMBEDDED))
 #define NULL ((void *)0)
 #define ERR(msg) /* { printf msg; } */
-#else
-#include <stdio.h>
+#elif !defined(WIN32)
+#define NULL ((void *)0)
+#define ERR(msg) /* { printf msg; } */
 #include <unistd.h>
 #include <string.h>
+#else
+#include <stdio.h>
 #define ERR(msg) \
   { printf msg; }
 #endif
@@ -84,7 +87,7 @@ int main(int argc, char **argv) {
 
   pfSetQuiet(FALSE);
 /* Parse command line. */
-#if (defined(PF_NO_STDIO) || defined(PF_EMBEDDED))
+#if (defined(PF_NO_STDIO) || defined(PF_EMBEDDED) || defined(WIN32))
   for (i = 1; i < argc; i++) {
     s = argv[i];
 
@@ -142,7 +145,6 @@ int main(int argc, char **argv) {
           DicName = PF_DEFAULT_DICTIONARY;
         }
         else {
-          printf("DIC %s\n", optarg);
           DicName = strdup(optarg);
         }
         break;


### PR DESCRIPTION
https://github.com/philburk/pforth/issues/131

Added getopt to parse arguments. 

Removed a compiler flag that was being flagged with a warning message on my Mac.

Not sure why this can't automatically merge.  Maybe you need to fix something in your repo?

I didn't test on linux.  Don't see why it wouldn't work identically.  The getopt() function is in <unistd.h>.

No change in functionality except: added -h and -? for help:
```
./pforth -h           
Usage:
        pforth {-i} {-q} {-d filename.dic} {sourcefilename}
```

```
./pforth   
PForth V28-LE/64, built Dec 11 2022 16:35:27
pForth loading dictionary from file pforth.dic
     File format version is 10 
     Name space size = 120000 
     Code space size = 300000 
     Entry Point     = 0 
     Cell Size       = 8 
     Little  Endian Dictionary

1 1 +    ok
Stack<10> 2 
```

Note that make test with the main branch code reports the same one error as this PR.

Output of 'make test':
```
make test         
wd=$(pwd); (cd ../../fth; ${wd}/pforth_standalone -q t_corex.fth)
Include t_tools.fth
    include added 1496 bytes,38508 left.
IF YOU SEE THIS THEN .( WORKED!
    1234 - SHOULD LINE UP WITH NEXT LINE.
    1234
TEST NULL STRING IN .( 
10 9 8 7 6 5 

    ABCD4321 - SHOULD LINE UP WITH NEXT LINE.
    ABCD4321
 108 passed,    0 failed.
wd=$(pwd); (cd ../../fth; ${wd}/pforth_standalone -q t_strings.fth)
Include t_tools.fth
    include added 1496 bytes,38508 left.
  36 passed,    0 failed.
wd=$(pwd); (cd ../../fth; ${wd}/pforth_standalone -q t_locals.fth)
Include t_tools.fth
    include added 1496 bytes,38508 left.
Test warning when no locals defined.
(LOCAL) - Warning: no locals defined!
   9 passed,    0 failed.
wd=$(pwd); (cd ../../fth; ${wd}/pforth_standalone -q t_alloc.fth)
Testing ALLOCATE and FREE
10000 tests
Total Avail = 40960 
Please wait for test to complete...
Final    MAX = 40960 
Original MAX = 40960 
Test PASSED.
wd=$(pwd); (cd ../../fth; ${wd}/pforth_standalone -q t_floats.fth)
Include t_tools.fth
    include added 1496 bytes,38508 left.
T_F. T.SERIES final = 1.234533e+17 
T_F. T.SERIES final = 1.234533e+17 
T_F. T.SERIES final = 9.303299e+20 
T_F>D T.SERIES final = 1.175126e+17 
T_FS. T.SERIES final = 1.081004e+16 
T_FS. T.SERIES final = 6.448631e-18 
T_FE. T.SERIES final = 1.601179e+17 
T_FE. T.SERIES final = 1.219607e-18 
T_FE. T.SERIES final = 1.019165e+23 
T_FE. T.SERIES final = 2.103802e-12 
  49 passed,    0 failed.
wd=$(pwd); (cd ../../fth; ${wd}/pforth_standalone -q t_file.fth)
Include t_tools.fth
    include added 1496 bytes,38508 left.
Include t_required_helper1.fth
    include added 0 bytes,37388 left.
Include t_required_helper1.fth
    include added 0 bytes,37388 left.
Include t_required_helper2.fth
    include added 0 bytes,37388 left.
Include t_required_helper2.fth
    include added 0 bytes,37388 left.
INCORRECT RESULT: T{ S" abcd"  S" 1234" SSQ13  S= ROT ROT SSQ12 S= -> TRUE TRUE }T
  90 passed,    1 failed.
```
