### PR TITLE
Add VERSION_CODE and print normal version

### DIFF
--- a/csrc/pf_core.c
+++ b/csrc/pf_core.c
@@ -460,9 +460,10 @@ ThrowCode pfDoForth( const char *DicFileName, const char *SourceName, cell_t IfI
 
         if( !gVarQuiet )
         {
-            MSG( "PForth V"PFORTH_VERSION );
-            if( IsHostLittleEndian() ) MSG("-LE");
-            else MSG("-BE");
+            MSG( "PForth V"PFORTH_VERSION_NAME", " );
+
+            if( IsHostLittleEndian() ) MSG("LE");
+            else MSG("BE");
 #if PF_BIG_ENDIAN_DIC
             MSG("/BE");
 #elif PF_LITTLE_ENDIAN_DIC

--- a/csrc/pf_guts.h
+++ b/csrc/pf_guts.h
@@ -26,7 +26,8 @@
 ** PFORTH_VERSION changes when PForth is modified and released.
 ** See README file for version info.
 */
-#define PFORTH_VERSION "28"
+#define PFORTH_VERSION_CODE 29
+#define PFORTH_VERSION_NAME "2.0.0"
 
 /*
 ** PFORTH_FILE_VERSION changes when incompatible changes are made
@@ -290,12 +291,12 @@ enum cforth_primitive_ids
     ID_FILE_RESIZE,    /* RESIZE-FILE */
     ID_SLEEP_P,        /* (SLEEP) V2.0.0 */
     ID_VAR_BYE_CODE,   /* BYE-CODE */
-    /* If you add a word here, take away one reserved word below. */
+    ID_VERSION_CODE,
+/* If you add a word here, take away one reserved word below. */
 #ifdef PF_SUPPORT_FP
 /* Only reserve space if we are adding FP so that we can detect
 ** unsupported primitives when loading dictionary.
 */
-    ID_RESERVED02,
     ID_RESERVED03,
     ID_RESERVED04,
     ID_RESERVED05,

--- a/csrc/pf_inner.c
+++ b/csrc/pf_inner.c
@@ -1805,6 +1805,11 @@ DBUG(("XX ah,m,l = 0x%8x,%8x,%8x - qh,l = 0x%8x,%8x\n", ah,am,al, qh,ql ));
         case ID_VAR_TRACE_STACK: DO_VAR(gVarTraceStack); endcase;
         case ID_VAR_RETURN_CODE: DO_VAR(gVarReturnCode); endcase;
 
+        case ID_VERSION_CODE:
+            M_PUSH( TOS );
+            TOS = PFORTH_VERSION_CODE;
+            endcase;
+
         case ID_WORD:
             TOS = (cell_t) ffWord( (char) TOS );
             endcase;

--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -378,6 +378,7 @@ PForthDictionary pfBuildDictionary( cell_t HeaderSize, cell_t CodeSize )
     CreateDicEntryC( ID_VAR_OUT, "OUT", 0 );
     CreateDicEntryC( ID_VAR_STATE, "STATE", 0 );
     CreateDicEntryC( ID_VAR_TO_IN, ">IN", 0 );
+    CreateDicEntryC( ID_VERSION_CODE, "VERSION_CODE", 0 );
     CreateDicEntryC( ID_WORD, "WORD", 0 );
     CreateDicEntryC( ID_WORD_FETCH, "W@", 0 );
     CreateDicEntryC( ID_WORD_STORE, "W!", 0 );


### PR DESCRIPTION
This will make pForth more consistent with other packages that use version names like "2.0.0"

Fixes #99