### PR TITLE
Fix Windows CMAKE Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,12 @@ if(WIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     message("Warning: _CRT_SECURE_NO_WARNINGS")
     set(PFORTH_EXE Debug/pforth.exe)
+	set(PFORTH_EXTRA_LIBS )
 endif(WIN32)
 
 if(UNIX OR APPLE)
     set(PFORTH_EXE pforth)
+	set(PFORTH_EXTRA_LIBS m)
 endif(UNIX OR APPLE)
 
 add_subdirectory(csrc)
@@ -60,7 +62,7 @@ endif(UNISTD)
 
 # 1. Build pforth executable
 add_executable(pforth csrc/pf_main.c)
-target_link_libraries(pforth ${PROJECT_NAME}_lib)
+target_link_libraries(pforth ${PROJECT_NAME}_lib ${PFORTH_EXTRA_LIBS})
 
 # 2. Build pforth.dic by compiling system.fth
 set(PFORTH_DIC "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pforth.dic")
@@ -89,6 +91,6 @@ add_dependencies(${PROJECT_NAME}_lib_sd pforth_dic_header)
 
 # 4. Build pforth_standalone using the precompiled dictionary.
 add_executable(pforth_standalone csrc/pf_main.c)
-target_link_libraries(pforth_standalone ${PROJECT_NAME}_lib_sd)
+target_link_libraries(pforth_standalone ${PROJECT_NAME}_lib_sd ${PFORTH_EXTRA_LIBS})
 target_compile_definitions(pforth_standalone PRIVATE PF_STATIC_DIC)
 add_dependencies(pforth_standalone pforth_dic_header)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #    make
 #
 # That will create the following files:
-#    fth/pforth   # executable that loads pforth.dic
+#    fth/pforth   # executable that loads pforth.dic (pforth.exe on Windows)
 #    fth/pforth.dic
 #    fth/pforth_standalone # executable that does not need a .dic file
 #
@@ -26,7 +26,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Put pforth in the fth folder so we can load the Forth code more easily.
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/fth)
+set(PFORTH_FTH_DIR ${CMAKE_SOURCE_DIR}/fth)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PFORTH_FTH_DIR})
 
 project(PForth)
 message("Configuring ${PROJECT_NAME}...")
@@ -35,7 +36,12 @@ enable_testing()
 if(WIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     message("Warning: _CRT_SECURE_NO_WARNINGS")
+    set(PFORTH_EXE Debug/pforth.exe)
 endif(WIN32)
+
+if(UNIX OR APPLE)
+    set(PFORTH_EXE pforth)
+endif(UNIX OR APPLE)
 
 add_subdirectory(csrc)
 if(NOT WIN32 AND NOT APPLE)
@@ -54,12 +60,12 @@ endif(UNISTD)
 
 # 1. Build pforth executable
 add_executable(pforth csrc/pf_main.c)
-target_link_libraries(pforth ${PROJECT_NAME}_lib m)
+target_link_libraries(pforth ${PROJECT_NAME}_lib)
 
 # 2. Build pforth.dic by compiling system.fth
 set(PFORTH_DIC "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pforth.dic")
 add_custom_command(OUTPUT ${PFORTH_DIC}
-  COMMAND ./pforth -i system.fth
+  COMMAND ./${PFORTH_EXE} -i ${PFORTH_FTH_DIR}/system.fth
   WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
   DEPENDS pforth
   COMMENT Building pforth.dic
@@ -71,8 +77,8 @@ add_custom_target(pforth_dic DEPENDS ${PFORTH_DIC})
 #    as C source code.
 set(PFORTH_DIC_HEADER "csrc/pfdicdat.h")
 add_custom_command(OUTPUT ${PFORTH_DIC_HEADER}
-  COMMAND ./pforth mkdicdat.fth
-  COMMAND mv pfdicdat.h ../csrc/.
+  COMMAND ./${PFORTH_EXE} ${PFORTH_FTH_DIR}/mkdicdat.fth
+  COMMAND ${CMAKE_COMMAND} -E rename pfdicdat.h ../csrc/pfdicdat.h
   WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
   DEPENDS pforth_dic
   COMMENT Building pfdicdat.h
@@ -83,9 +89,6 @@ add_dependencies(${PROJECT_NAME}_lib_sd pforth_dic_header)
 
 # 4. Build pforth_standalone using the precompiled dictionary.
 add_executable(pforth_standalone csrc/pf_main.c)
-target_link_libraries(pforth_standalone ${PROJECT_NAME}_lib_sd m)
+target_link_libraries(pforth_standalone ${PROJECT_NAME}_lib_sd)
 target_compile_definitions(pforth_standalone PRIVATE PF_STATIC_DIC)
 add_dependencies(pforth_standalone pforth_dic_header)
-
-
-

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -14,7 +14,7 @@ endif(UNIX OR APPLE)
 
 if (MSVC)
     # warning level 4 and all warnings as errors
-    add_compile_options(/W4 /WX)
+    add_compile_options(/W4)
 else()
     # lots of warnings and all warnings as errors
     add_compile_options(

--- a/csrc/pf_core.c
+++ b/csrc/pf_core.c
@@ -472,14 +472,12 @@ ThrowCode pfDoForth( const char *DicFileName, const char *SourceName, cell_t IfI
 #elif PF_LITTLE_ENDIAN_DIC
             MSG("/LE");
 #endif
-            if (sizeof(cell_t) == 8)
-            {
+
+#if (PF_SIZEOF_CELL == 8)
                 MSG("/64");
-            }
-            else if (sizeof(cell_t) == 4)
-            {
+#elif (PF_SIZEOF_CELL  == 4)
                 MSG("/32");
-            }
+#endif
 
             MSG( ", built "__DATE__" "__TIME__ );
         }

--- a/csrc/pf_inner.c
+++ b/csrc/pf_inner.c
@@ -200,15 +200,18 @@ static void TraceNames( ExecToken Token, cell_t Level )
 /* Truncate the unsigned double cell integer LO/HI to an uint64_t. */
 static uint64_t UdToUint64( ucell_t Lo, ucell_t Hi )
 {
-    return (( 2 * sizeof(ucell_t) == sizeof(uint64_t) )
-        ? (((uint64_t)Lo) | (((uint64_t)Hi) >> (sizeof(ucell_t) * 8)))
-        : Lo);
+#if (PF_SIZEOF_CELL == 4)
+    return (((uint64_t)Lo) | (((uint64_t)Hi) >> (sizeof(ucell_t) * 8)));
+#else
+    (void)Hi;
+    return Lo;
+#endif
 }
 
 /* Return TRUE if the unsigned double cell integer LO/HI is not greater
  * then the greatest uint64_t.
  */
-static int UdIsUint64( ucell_t Lo, ucell_t Hi )
+static int UdIsUint64( ucell_t Hi )
 {
     return (( 2 * sizeof(ucell_t) == sizeof(uint64_t) )
         ? TRUE
@@ -1158,7 +1161,7 @@ DBUG(("XX ah,m,l = 0x%8x,%8x,%8x - qh,l = 0x%8x,%8x\n", ah,am,al, qh,ql ));
 		FileStream *File = (FileStream *) TOS;
 		ucell_t SizeHi = (ucell_t) M_POP;
 		ucell_t SizeLo = (ucell_t) M_POP;
-		TOS = ( UdIsUint64( SizeLo, SizeHi )
+		TOS = ( UdIsUint64( SizeHi )
 			? sdResizeFile( File, UdToUint64( SizeLo, SizeHi ))
 			: THROW_RESIZE_FILE );
 	    }

--- a/csrc/pforth.h
+++ b/csrc/pforth.h
@@ -32,6 +32,7 @@ typedef void *PForthDictionary;
 #include <stdint.h>
 /* Integer types for Forth cells, signed and unsigned: */
 typedef intptr_t cell_t;
+#define PF_SIZEOF_CELL __SIZEOF_INTPTR__
 typedef uintptr_t ucell_t;
 
 typedef ucell_t ExecToken;              /* Execution Token */

--- a/csrc/win32_console/pf_io_win32_console.c
+++ b/csrc/win32_console/pf_io_win32_console.c
@@ -231,4 +231,11 @@ void sdTerminalInit( void )
 void sdTerminalTerm( void )
 {
 }
+
+cell_t sdSleepMillis(cell_t msec)
+{
+    Sleep(msec);
+    return 0;
+}
+
 #endif


### PR DESCRIPTION
Use pforth.exe
Use cross platform command to move a file.
Disable warnings as errors, "/WX".
Use some C tricks to prevent compiler warnings.

See Issue #148