### PR TITLE
Fix buffer overflow in zero terminator code for debugging

### DIFF
--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -1141,7 +1141,7 @@ DBUGX(("readLineFromStream(0x%x, 0x%x, 0x%x)\n", buffer, len, stream ));
     }
 
 /* NUL terminate line to simplify printing when debugging. */
-    if( (len >= 0) && (len < maxChars) ) p[len] = '\0';
+    if( (len >= 0) && (len < maxChars) ) *p = '\0';
 
     return len;
 }


### PR DESCRIPTION
Simple change to avoid segmentation fault caused by zero terminator being written in wrong place, especially bad on lines longer than half the TIB size. 

Fixes #174 