### PR TITLE
Long name support

### DIFF
--- a/csrc/pf_cglue.c
+++ b/csrc/pf_cglue.c
@@ -86,7 +86,7 @@ DBUG(("CallUserFunction: Index = %d, ReturnMode = %d, NumParams = %d\n",
 Err CreateGlueToC( const char *CName, ucell_t Index, cell_t ReturnMode, int32_t NumParams )
 {
     ucell_t Packed;
-    char FName[70];
+    char FName[LONGEST_WORD_NAME+9];    // +1 for length, up to +9 should not be used, but is here for safety
 
     CStringToForth( FName, CName, sizeof(FName) );
     Packed = (Index & 0xFFFF) | 0 | (NumParams << 24) |

--- a/csrc/pf_cglue.c
+++ b/csrc/pf_cglue.c
@@ -86,7 +86,7 @@ DBUG(("CallUserFunction: Index = %d, ReturnMode = %d, NumParams = %d\n",
 Err CreateGlueToC( const char *CName, ucell_t Index, cell_t ReturnMode, int32_t NumParams )
 {
     ucell_t Packed;
-    char FName[LONGEST_WORD_NAME+9];    // +1 for length, up to +9 should not be used, but is here for safety
+    char FName[LONGEST_WORD_NAME+9];    /* +1 for length, up to +9 should not be used, but is here for safety */
 
     CStringToForth( FName, CName, sizeof(FName) );
     Packed = (Index & 0xFFFF) | 0 | (NumParams << 24) |

--- a/csrc/pf_cglue.c
+++ b/csrc/pf_cglue.c
@@ -86,7 +86,7 @@ DBUG(("CallUserFunction: Index = %d, ReturnMode = %d, NumParams = %d\n",
 Err CreateGlueToC( const char *CName, ucell_t Index, cell_t ReturnMode, int32_t NumParams )
 {
     ucell_t Packed;
-    char FName[40];
+    char FName[70];
 
     CStringToForth( FName, CName, sizeof(FName) );
     Packed = (Index & 0xFFFF) | 0 | (NumParams << 24) |

--- a/csrc/pf_guts.h
+++ b/csrc/pf_guts.h
@@ -29,13 +29,14 @@
 #define PFORTH_VERSION_CODE 33
 #define PFORTH_VERSION_NAME "2.1.1"
 
-// Most Forth word names are short - so 31 characters should be enough.
-// However if you are integrating with other systems - for example libSDL
-// some names are longer than 31 characters. This provides up to 63 characters 
-// for a word names.
-//
-// Long term this can become the default since there is no storage penalty
-// when not using them.
+/* Most Forth word names are short - so 31 characters should be enough.
+ * However if you are integrating with other systems - for example libSDL
+ * some names are longer than 31 characters. This provides up to 63 characters 
+ * for a word names.
+ *
+ * Long term this can become the default since there is no storage penalty
+ * when not using them.
+ */
 #define LONG_NAME_SUPPORT
 
 /*
@@ -51,7 +52,7 @@
 ** FV9 - 20100503 - Added support for 64-bit CELL.
 ** FV10 - 20170103 - Added ID_FILE_FLUSH ID_FILE_RENAME ID_FILE_RESIZE
 ** FV11 - 20241226 - Added ID_SLEEP_P, ID_VAR_BYE_CODE, ID_VERSION_CODE
-** FV12 - 20241227 - Added Long name support, ID_FLAG_SMUDGE, ID_NAME_MASK_SIZE
+** FV12 - 20241227 - Added Long name support, ID_FLAG_SMUDGE, ID_MASK_NAME_SIZE
 */
 
 #define PF_FILE_VERSION (12)   /* Bump this whenever primitives added. */
@@ -90,7 +91,7 @@
 #define MASK_NAME_SIZE  (0x1F)
 #endif
 
-// these the same, but have different names for clarity
+/* these the same, but have different names for clarity */
 #define LONGEST_WORD_NAME MASK_NAME_SIZE
 
 /* Debug TRACE flags */
@@ -319,7 +320,7 @@ enum cforth_primitive_ids
     ID_VAR_BYE_CODE,   /* BYE-CODE */
     ID_VERSION_CODE,
     ID_FLAG_SMUDGE,
-    ID_NAME_MASK_SIZE,
+    ID_MASK_NAME_SIZE,
 /* If you add a word above here,
 **   1. update PF_FILE_VERSION
 **   2. take away one reserved word below

--- a/csrc/pf_guts.h
+++ b/csrc/pf_guts.h
@@ -29,7 +29,9 @@
 #define PFORTH_VERSION_CODE 33
 #define PFORTH_VERSION_NAME "2.1.1"
 
-/* Most Forth word names are short - so 31 characters should be enough.
+/* 
+ * NOTES about PF_SUPPORT_LONG_NAMES
+ * Most Forth word names are short - so 31 characters should be enough.
  * However if you are integrating with other systems - for example libSDL
  * some names are longer than 31 characters. This provides up to 63 characters 
  * for word names.
@@ -37,7 +39,6 @@
  * Long term this can become the default since there is no storage penalty
  * when not using them.
  */
-#define LONG_NAME_SUPPORT
 
 /*
 ** PFORTH_FILE_VERSION changes when incompatible changes are made
@@ -57,7 +58,7 @@
 
 #define PF_FILE_VERSION (12)   /* Bump this whenever primitives added. */
 
-#if defined(LONG_NAME_SUPPORT)
+#if defined(PF_SUPPORT_LONG_NAMES)
 #define PF_EARLIEST_FILE_VERSION (12)  /* earliest one still compatible */
 #else
 #define PF_EARLIEST_FILE_VERSION (9)  /* earliest one still compatible */
@@ -80,10 +81,11 @@
 #define FTRUE (-1)
 #define BLANK (' ')
 
-/* #define FLAG_PRECEDENCE (0x80) */
+ /* The IMMEDIATE flag is known as the "precedence bit" on some other Forth systems. */
+ /* #define FLAG_PRECEDENCE (0x80) */
 #define FLAG_IMMEDIATE  (0x40)
 
-#ifdef LONG_NAME_SUPPORT
+#ifdef PF_SUPPORT_LONG_NAMES
 #define FLAG_SMUDGE     (0x80)
 #define MASK_NAME_SIZE  (0x3F)
 #else

--- a/csrc/pf_guts.h
+++ b/csrc/pf_guts.h
@@ -63,10 +63,10 @@
 #define FTRUE (-1)
 #define BLANK (' ')
 
-#define FLAG_PRECEDENCE (0x80)
+/* #define FLAG_PRECEDENCE (0x80) */
 #define FLAG_IMMEDIATE  (0x40)
-#define FLAG_SMUDGE     (0x20)
-#define MASK_NAME_SIZE  (0x1F)
+#define FLAG_SMUDGE     (0x80)
+#define MASK_NAME_SIZE  (0x3F)
 
 /* Debug TRACE flags */
 #define TRACE_INNER     (0x0002)

--- a/csrc/pf_guts.h
+++ b/csrc/pf_guts.h
@@ -26,8 +26,17 @@
 ** PFORTH_VERSION changes when PForth is modified.
 ** See README file for version info.
 */
-#define PFORTH_VERSION_CODE 32
-#define PFORTH_VERSION_NAME "2.1.0"
+#define PFORTH_VERSION_CODE 33
+#define PFORTH_VERSION_NAME "2.1.1"
+
+// Most Forth word names are short - so 31 characters should be enough.
+// However if you are integrating with other systems - for example libSDL
+// some names are longer than 31 characters. This provides up to 63 characters 
+// for a word names.
+//
+// Long term this can become the default since there is no storage penalty
+// when not using them.
+#define LONG_NAME_SUPPORT
 
 /*
 ** PFORTH_FILE_VERSION changes when incompatible changes are made
@@ -42,9 +51,16 @@
 ** FV9 - 20100503 - Added support for 64-bit CELL.
 ** FV10 - 20170103 - Added ID_FILE_FLUSH ID_FILE_RENAME ID_FILE_RESIZE
 ** FV11 - 20241226 - Added ID_SLEEP_P, ID_VAR_BYE_CODE, ID_VERSION_CODE
+** FV12 - 20241227 - Added Long name support, ID_FLAG_SMUDGE, ID_NAME_MASK_SIZE
 */
-#define PF_FILE_VERSION (11)   /* Bump this whenever primitives added. */
+
+#define PF_FILE_VERSION (12)   /* Bump this whenever primitives added. */
+
+#if defined(LONG_NAME_SUPPORT)
+#define PF_EARLIEST_FILE_VERSION (12)  /* earliest one still compatible */
+#else
 #define PF_EARLIEST_FILE_VERSION (9)  /* earliest one still compatible */
+#endif
 
 /***************************************************************
 ** Sizes and other constants
@@ -65,8 +81,17 @@
 
 /* #define FLAG_PRECEDENCE (0x80) */
 #define FLAG_IMMEDIATE  (0x40)
+
+#ifdef LONG_NAME_SUPPORT
 #define FLAG_SMUDGE     (0x80)
 #define MASK_NAME_SIZE  (0x3F)
+#else
+#define FLAG_SMUDGE     (0x20)
+#define MASK_NAME_SIZE  (0x1F)
+#endif
+
+// these the same, but have different names for clarity
+#define LONGEST_WORD_NAME MASK_NAME_SIZE
 
 /* Debug TRACE flags */
 #define TRACE_INNER     (0x0002)
@@ -293,6 +318,8 @@ enum cforth_primitive_ids
     ID_SLEEP_P,        /* (SLEEP) V2.0.0 */
     ID_VAR_BYE_CODE,   /* BYE-CODE */
     ID_VERSION_CODE,
+    ID_FLAG_SMUDGE,
+    ID_NAME_MASK_SIZE,
 /* If you add a word above here,
 **   1. update PF_FILE_VERSION
 **   2. take away one reserved word below
@@ -301,8 +328,6 @@ enum cforth_primitive_ids
 /* Only reserve space if we are adding FP so that we can detect
 ** unsupported primitives when loading dictionary.
 */
-    ID_RESERVED03,
-    ID_RESERVED04,
     ID_RESERVED05,
     ID_RESERVED06,
     ID_RESERVED07,

--- a/csrc/pf_guts.h
+++ b/csrc/pf_guts.h
@@ -32,7 +32,7 @@
 /* Most Forth word names are short - so 31 characters should be enough.
  * However if you are integrating with other systems - for example libSDL
  * some names are longer than 31 characters. This provides up to 63 characters 
- * for a word names.
+ * for word names.
  *
  * Long term this can become the default since there is no storage penalty
  * when not using them.

--- a/csrc/pf_inner.c
+++ b/csrc/pf_inner.c
@@ -1867,6 +1867,16 @@ DBUGX(("Before 0Branch: IP = 0x%x\n", InsPtr ));
 DBUGX(("After 0Branch: IP = 0x%x\n", InsPtr ));
             endcase;
 
+        case ID_FLAG_SMUDGE:
+            M_PUSH( TOS );
+            TOS = FLAG_SMUDGE;
+            endcase;
+
+        case ID_MASK_NAME_SIZE:
+            PUSH_TOS;
+            TOS = (cell_t) MASK_NAME_SIZE;
+            endcase;
+
         default:
             ERR("pfCatch: Unrecognised token = 0x");
             ffDotHex(Token);

--- a/csrc/pf_text.c
+++ b/csrc/pf_text.c
@@ -340,7 +340,7 @@ void TypeName( const char *Name )
     cell_t Len;
 
     FirstChar = Name+1;
-    Len = *Name & 0x3F;
+    Len = *Name & MASK_NAME_SIZE;
 
     ioType( FirstChar, Len );
 }

--- a/csrc/pf_text.c
+++ b/csrc/pf_text.c
@@ -340,7 +340,7 @@ void TypeName( const char *Name )
     cell_t Len;
 
     FirstChar = Name+1;
-    Len = *Name & 0x1F;
+    Len = *Name & 0x3F;
 
     ioType( FirstChar, Len );
 }

--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -99,7 +99,7 @@ void CreateDicEntry( ExecToken XT, const ForthStringPtr FName, ucell_t Flags )
 */
 void CreateDicEntryC( ExecToken XT, const char *CName, ucell_t Flags )
 {
-    ForthString FName[40];
+    ForthString FName[70];
     CStringToForth( FName, CName, sizeof(FName) );
     CreateDicEntry( XT, FName, Flags );
 }
@@ -460,7 +460,7 @@ cell_t ffFindNFA( const ForthString *WordName, const ForthString **NFAPtr )
     cell_t Searching = TRUE;
     cell_t Result = 0;
 
-    WordLen = (uint8_t) ((ucell_t)*WordName & 0x1F);
+    WordLen = (uint8_t) ((ucell_t)*WordName & MASK_NAME_SIZE);
     WordChar = WordName+1;
 
     NameField = (ForthString *) gVarContext;
@@ -653,7 +653,7 @@ void ffStringDefer( const ForthStringPtr FName, ExecToken DefaultXT )
 /* Convert name then create deferred dictionary entry. */
 static void CreateDeferredC( ExecToken DefaultXT, const char *CName )
 {
-    char FName[40];
+    char FName[70];
     CStringToForth( FName, CName, sizeof(FName) );
     ffStringDefer( FName, DefaultXT );
 }

--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -99,7 +99,7 @@ void CreateDicEntry( ExecToken XT, const ForthStringPtr FName, ucell_t Flags )
 */
 void CreateDicEntryC( ExecToken XT, const char *CName, ucell_t Flags )
 {
-    ForthString FName[LONGEST_WORD_NAME+9];    // +1 for length, up to +9 should not be used, but is here for safety
+    ForthString FName[LONGEST_WORD_NAME+9];    /* +1 for length, up to +9 should not be used, but is here for safety */
     CStringToForth( FName, CName, sizeof(FName) );
     CreateDicEntry( XT, FName, Flags );
 }
@@ -385,7 +385,7 @@ PForthDictionary pfBuildDictionary( cell_t HeaderSize, cell_t CodeSize )
     CreateDicEntryC( ID_XOR, "XOR", 0 );
     CreateDicEntryC( ID_ZERO_BRANCH, "0BRANCH", 0 );
     CreateDicEntryC( ID_FLAG_SMUDGE, "FLAG_SMUDGE", 0 );
-    CreateDicEntryC( ID_NAME_MASK_SIZE, "MASK_NAME_SIZE", 0 );
+    CreateDicEntryC( ID_MASK_NAME_SIZE, "MASK_NAME_SIZE", 0 );
 
     pfDebugMessage("pfBuildDictionary: FindSpecialXTs\n");
     if( FindSpecialXTs() < 0 ) goto error;
@@ -655,7 +655,7 @@ void ffStringDefer( const ForthStringPtr FName, ExecToken DefaultXT )
 /* Convert name then create deferred dictionary entry. */
 static void CreateDeferredC( ExecToken DefaultXT, const char *CName )
 {
-    char FName[LONGEST_WORD_NAME+9];    // +1 for length, up to +9 should not be used, but is here for safety
+    char FName[LONGEST_WORD_NAME+9];    /* +1 for length, up to +9 should not be used, but is here for safety */
     CStringToForth( FName, CName, sizeof(FName) );
     ffStringDefer( FName, DefaultXT );
 }

--- a/csrc/pfcompil.c
+++ b/csrc/pfcompil.c
@@ -99,7 +99,7 @@ void CreateDicEntry( ExecToken XT, const ForthStringPtr FName, ucell_t Flags )
 */
 void CreateDicEntryC( ExecToken XT, const char *CName, ucell_t Flags )
 {
-    ForthString FName[70];
+    ForthString FName[LONGEST_WORD_NAME+9];    // +1 for length, up to +9 should not be used, but is here for safety
     CStringToForth( FName, CName, sizeof(FName) );
     CreateDicEntry( XT, FName, Flags );
 }
@@ -384,6 +384,8 @@ PForthDictionary pfBuildDictionary( cell_t HeaderSize, cell_t CodeSize )
     CreateDicEntryC( ID_WORD_STORE, "W!", 0 );
     CreateDicEntryC( ID_XOR, "XOR", 0 );
     CreateDicEntryC( ID_ZERO_BRANCH, "0BRANCH", 0 );
+    CreateDicEntryC( ID_FLAG_SMUDGE, "FLAG_SMUDGE", 0 );
+    CreateDicEntryC( ID_NAME_MASK_SIZE, "MASK_NAME_SIZE", 0 );
 
     pfDebugMessage("pfBuildDictionary: FindSpecialXTs\n");
     if( FindSpecialXTs() < 0 ) goto error;
@@ -653,7 +655,7 @@ void ffStringDefer( const ForthStringPtr FName, ExecToken DefaultXT )
 /* Convert name then create deferred dictionary entry. */
 static void CreateDeferredC( ExecToken DefaultXT, const char *CName )
 {
-    char FName[70];
+    char FName[LONGEST_WORD_NAME+9];    // +1 for length, up to +9 should not be used, but is here for safety
     CStringToForth( FName, CName, sizeof(FName) );
     ffStringDefer( FName, DefaultXT );
 }

--- a/fth/ansilocs.fth
+++ b/fth/ansilocs.fth
@@ -32,7 +32,7 @@ private{
 
 decimal
 16 constant LV_MAX_VARS    \ maximum number of local variables
-63 constant LV_MAX_CHARS   \ maximum number of letters in name
+mask_name_size constant LV_MAX_CHARS   \ maximum number of letters in name
 
 lv_max_vars lv_max_chars $array LV-NAMES
 variable LV-#NAMES   \ number of names currently defined

--- a/fth/ansilocs.fth
+++ b/fth/ansilocs.fth
@@ -32,7 +32,7 @@ private{
 
 decimal
 16 constant LV_MAX_VARS    \ maximum number of local variables
-31 constant LV_MAX_CHARS   \ maximum number of letters in name
+63 constant LV_MAX_CHARS   \ maximum number of letters in name
 
 lv_max_vars lv_max_chars $array LV-NAMES
 variable LV-#NAMES   \ number of names currently defined

--- a/fth/filefind.fth
+++ b/fth/filefind.fth
@@ -56,7 +56,7 @@ ANEW TASK-FILEFIND.FTH
                 OF
                     dpth 0=
                     IF
-                        nfa count 31 and
+                        nfa count 63 and
                         4 - swap 4 + swap
                         true -> stoploop
                     ELSE

--- a/fth/filefind.fth
+++ b/fth/filefind.fth
@@ -56,7 +56,7 @@ ANEW TASK-FILEFIND.FTH
                 OF
                     dpth 0=
                     IF
-                        nfa count 63 and
+                        nfa count mask_name_size and
                         4 - swap 4 + swap
                         true -> stoploop
                     ELSE

--- a/fth/misc1.fth
+++ b/fth/misc1.fth
@@ -100,8 +100,6 @@ variable TAB-WIDTH  8 TAB-WIDTH !
     tab-width @   swap - spaces
 ;
 
-$80 constant FLAG_SMUDGE
-
 \ Vocabulary listing
 : WORDS  ( -- )
     0 latest

--- a/fth/misc1.fth
+++ b/fth/misc1.fth
@@ -100,7 +100,7 @@ variable TAB-WIDTH  8 TAB-WIDTH !
     tab-width @   swap - spaces
 ;
 
-$ 20 constant FLAG_SMUDGE
+$80 constant FLAG_SMUDGE
 
 \ Vocabulary listing
 : WORDS  ( -- )

--- a/fth/system.fth
+++ b/fth/system.fth
@@ -102,7 +102,7 @@
 \ --------------------------------------------------------------------
 
 : ID.   ( nfa -- )
-    count 31 and type
+    count 63 and type
 ;
 
 : DECIMAL   10 base !  ;
@@ -143,7 +143,7 @@
 \ Dictionary conversions ------------------------------------------
 
 : N>NEXTLINK  ( nfa -- nextlink , traverses name field )
-        dup c@ 31 and 1+ + aligned
+        dup c@ 63 and 1+ + aligned
 ;
 
 : NAMEBASE  ( -- base-of-names )

--- a/fth/system.fth
+++ b/fth/system.fth
@@ -102,7 +102,7 @@
 \ --------------------------------------------------------------------
 
 : ID.   ( nfa -- )
-    count 63 and type
+    count mask_name_size and type
 ;
 
 : DECIMAL   10 base !  ;
@@ -143,7 +143,7 @@
 \ Dictionary conversions ------------------------------------------
 
 : N>NEXTLINK  ( nfa -- nextlink , traverses name field )
-        dup c@ 63 and 1+ + aligned
+        dup c@ mask_name_size and 1+ + aligned
 ;
 
 : NAMEBASE  ( -- base-of-names )

--- a/fth/wordslik.fth
+++ b/fth/wordslik.fth
@@ -25,7 +25,7 @@ decimal
 
 
 : PARTIAL.MATCH.NAME  ( $str1 nfa  -- flag , is $str1 in nfa ??? )
-    count $ 1F and
+    count $ 3F and
     rot count
     search
     >r 2drop r>

--- a/fth/wordslik.fth
+++ b/fth/wordslik.fth
@@ -25,7 +25,7 @@ decimal
 
 
 : PARTIAL.MATCH.NAME  ( $str1 nfa  -- flag , is $str1 in nfa ??? )
-    count $ 3F and
+    count mask_name_size and
     rot count
     search
     >r 2drop r>


### PR DESCRIPTION
This adds long word name support. 

Questions:
1. Currently this is gated by a #define `LONG_NAME_SUPPORT` - currently enabled, but it can be build without to support old dictionaries with a build - however, maybe we should remove this and only support long names?

2. I added two Primitive Token IDS - which expose the FLAG_SMUDGE and MASK_NAME_SIZE ... these allow the Forth files to not have magic numbers unrelated to the Forth core... I can understand why we didn't do this in the past (size), but I think the dependency is strong between the two - and the Forth code is clearer for it. However it is a design decision - so should we do this or revert this part? 

3. I left FLAG_PRECEDENCE commented out - maybe this should be removed. 

Name to long warnings/errors to be raised as a separate PR. 
