### PR TITLE
fix warnings in WriteCellBigEndian() for 32bit builds

### DIFF
--- a/csrc/pf_save.c
+++ b/csrc/pf_save.c
@@ -218,13 +218,12 @@ void WriteCellBigEndian( uint8_t *addr, ucell_t data )
 {
     /* Write should be in order of increasing address
      * to optimize for burst writes to DRAM. */
-    if( sizeof(ucell_t) == 8 )
-    {
+	#if (LONG_MAX > 2147483647)  /* LONG_MAX from limits.h: values > 2^31-1 indicates 64bit ints */
         *addr++ = (uint8_t) (data>>56);
         *addr++ = (uint8_t) (data>>48);
         *addr++ = (uint8_t) (data>>40);
         *addr++ = (uint8_t) (data>>32);
-    }
+	#endif
     *addr++ = (uint8_t) (data>>24);
     *addr++ = (uint8_t) (data>>16);
     *addr++ = (uint8_t) (data>>8);

--- a/csrc/pf_save.c
+++ b/csrc/pf_save.c
@@ -218,12 +218,12 @@ void WriteCellBigEndian( uint8_t *addr, ucell_t data )
 {
     /* Write should be in order of increasing address
      * to optimize for burst writes to DRAM. */
-	#if (LONG_MAX > 2147483647)  /* LONG_MAX from limits.h: values > 2^31-1 indicates 64bit ints */
+#if (PF_SIZEOF_CELL == 8)
         *addr++ = (uint8_t) (data>>56);
         *addr++ = (uint8_t) (data>>48);
         *addr++ = (uint8_t) (data>>40);
         *addr++ = (uint8_t) (data>>32);
-	#endif
+#endif   /* PF_SIZEOF_CELL */
     *addr++ = (uint8_t) (data>>24);
     *addr++ = (uint8_t) (data>>16);
     *addr++ = (uint8_t) (data>>8);


### PR DESCRIPTION
Adresses #183.

Instead of checking  sizeof(ucell_t) as function call conditional compilation is used.
```
void WriteCellBigEndian( uint8_t *addr, ucell_t data )
...
	#if (LONG_MAX > 2147483647)  /* LONG_MAX from limits.h: values > 2^31-1 indicates 64bit ints */
...
```

LONG_MAX will be set to 2147483647 = (2^32-1) for 32 bit builds (and greater values for 64bit builds).
If I read the documentation correctly LONG_MAX is part of POSIX 1003.
**Please verify that this does not impair any target platform.**

Solution was tested (make clean test) on Manjaro, FreeBSD and NetBSD for X86_64 architecture (64 bit)
and additionally on NetBSD for i386 architecture (32 bit).