### PR TITLE
suggested: make test displays (expected; actual) values for failed tests

### DIFF
--- a/fth/t_tools.fth
+++ b/fth/t_tools.fth
@@ -80,9 +80,9 @@ CREATE the-test 128 CHARS ALLOT
             else
                 -1 test-passed +!
                 1 test-failed +!
-                ." INCORRECT RESULT (got=" . 
-                ." , expected=" .
-                 s" ) from "
+                ." INCORRECT RESULT (got=" (.) type
+                ." , expected=" (.) type
+                s" ) from "
                 error
                 LEAVE
             THEN

--- a/fth/t_tools.fth
+++ b/fth/t_tools.fth
@@ -82,10 +82,7 @@ CREATE the-test 128 CHARS ALLOT
                 1 test-failed +!
                 ." (got=" (.) type
                 ." , expected=" (.) type ." ) "
-                .S INCORRECT RESULT: " error
-                ." , expected=" (.) type
-                s" ) from "
-                error
+                S" INCORRECT RESULT: " error
                 LEAVE
             THEN
         LOOP

--- a/fth/t_tools.fth
+++ b/fth/t_tools.fth
@@ -64,17 +64,6 @@ CREATE the-test 128 CHARS ALLOT
 ;
 
 
-: int>str s>d swap over dabs <# #s rot sign #> ;
-: concat { addr1 len1 addr2 len2 | addr3 len3 -- addr3 len3 }
-  \ concatenates string at addr2 to string at addr1
-  len1 len2 + dup -> len3
-  chars allocate abort" panic: can not allocate result buffer in concat" -> addr3
-  addr1 addr3        len1 cmove
-  addr2 addr3 len1 + len2 cmove
-  addr3 len3
-  ;
-: concat+free { addr1 len1 addr2 len2  -- addr3 len3 }
-  addr1 len1 addr2 len2 concat addr1 free abort" panic: can not free temporary buffer-1 in concat+free" ;
 : }T    \ ( ... -- ) Compare stack (expected) contents with saved
         \ (actual) contents.
     DEPTH
@@ -89,12 +78,11 @@ CREATE the-test 128 CHARS ALLOT
             if
                 2drop
             else
-                >R >R
                 -1 test-passed +!
                 1 test-failed +!
-                s" INCORRECT RESULT (expected=" R> int>str concat
-                s" , got="         concat+free  R> int>str concat+free
-                s" ): "            concat+free
+                ." INCORRECT RESULT (got=" . 
+                ." , expected=" .
+                 s" ) from "
                 error
                 LEAVE
             THEN

--- a/fth/t_tools.fth
+++ b/fth/t_tools.fth
@@ -80,7 +80,9 @@ CREATE the-test 128 CHARS ALLOT
             else
                 -1 test-passed +!
                 1 test-failed +!
-                ." INCORRECT RESULT (got=" (.) type
+                ." (got=" (.) type
+                ." , expected=" (.) type ." ) "
+                .S INCORRECT RESULT: " error
                 ." , expected=" (.) type
                 s" ) from "
                 error


### PR DESCRIPTION
It would greatly help debugging if a failed test case (e.g. in make test) would return the offending value.

Here's an example from the current MSYS2-Cygwin environment 
(fixing RESIZE-FILE on this platform is a separate topic).

OOTB we get:
```
cd ../../fth && ../platforms/unix/pforth_standalone -q t_file.fth
...
INCORRECT RESULT: T{ FID2 @ FILE-SIZE -> 37. 0 }T
INCORRECT RESULT: T{ CBUF BUF 100 FID2 @ READ-FILE -> 37 0 }T
INCORRECT RESULT: T{ PAD 38 BUF 38 S= -> FALSE }T
...
  91 passed,    3 failed.
```
The suggested change would give us:
```
cd ../../fth && ../platforms/unix/pforth_standalone -q t_file.fth
...
INCORRECT RESULT (expected=37, got=87): T{ FID2 @ FILE-SIZE -> 37. 0 }T
INCORRECT RESULT (expected=37, got=87): T{ CBUF BUF 100 FID2 @ READ-FILE -> 37 0 }T
INCORRECT RESULT (expected=0, got=-1): T{ PAD 38 BUF 38 S= -> FALSE }T
...
  91 passed,    3 failed.
```

I do have a few concerns about int>str, concat and concat+free though:
- Are similar words already defined elsewhere perhaps?
- Is this the right place to define them (instead of e.g. t_strings.fth or strings.fth)? 
For now I preferred NOT to create a dependancy to other forth code files.

Feedback is welcome.