### PR TITLE
Makefile works around clangs c99 on FreeBSD

### DIFF
--- a/platforms/unix/Makefile
+++ b/platforms/unix/Makefile
@@ -62,6 +62,10 @@ EMBCCOPTS = -DPF_STATIC_DIC #-DPF_NO_FILEIO
 ifeq "$(UNAME)" "Darwin"
 	CC=clang
 endif
+# c99 on FreeBSD does not accept '-x' option
+ifeq "$(UNAME)" "FreeBSD"
+	CC=clang
+endif
 
 #######################################
 PFINCLUDES = pf_all.h pf_cglue.h pf_clib.h pf_core.h pf_float.h \


### PR DESCRIPTION
FreeBSD seems to have a similar problem as was already fixed for Darwin:
Here the c99 executable rejects the '-x' switch.

Using 'clang' instead fixes the problem here as well.

Note: I did not find a way to express:
```
if equals("$os", "Darwin") || equals("$os", "FreeBSD")
``` 
... which can actually be read and understood easily. 
Suggestions are welcome.

Tested with FreeBSD 13.2-RELEASE.