### PR TITLE
TruncateFile aborts on MSYS/Cygwin

### DIFF
--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -108,6 +108,7 @@ static bool_t TruncateFile( FileStream *File, long Newsize )
             if( CopyFile( File, TmpFile, Newsize )) goto cleanup;
             if( fseek( TmpFile, 0, SEEK_SET ) != 0 ) goto cleanup;
             if( freopen( getFilePathFromStream(File), "w+b", File ) == NULL ) goto cleanup;
+            if( ftell(File)!=0 ) goto cleanup;  /* Cygwin reopens File BEHIND the content */
             if( CopyFile( TmpFile, File, Newsize )) goto cleanup;
             Error = FALSE;
 

--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -108,7 +108,7 @@ static bool_t TruncateFile( FileStream *File, long Newsize )
             if( CopyFile( File, TmpFile, Newsize )) goto cleanup;
             if( fseek( TmpFile, 0, SEEK_SET ) != 0 ) goto cleanup;
             if( freopen( getFilePathFromStream(File), "w+b", File ) == NULL ) goto cleanup;
-            if( ftell(File)!=0 ) goto cleanup;  /* Cygwin reopens File BEHIND the content */
+            if( ftell(File) != 0 ) goto cleanup;  /* Cygwin reopens File BEHIND the content */
             if( CopyFile( TmpFile, File, Newsize )) goto cleanup;
             Error = FALSE;
 


### PR DESCRIPTION
I could not find an obvious way to fix #189.

This patch aborts RESIZE-FILE (for shrinking) on MSYS2/Cygwin instead of silently appending to the existing file.
Which is just a tiny bit better.

If there should be nothing (else) we could do about it, I would advocate documenting the behaviour
(e.g. in README.md),

Hints are welcome.


Output for make test on {Linux, FreeBsd,NetBSD} is now:
```
cd ../../fth && ../platforms/unix/pforth_standalone -q t_file.fth
Include t_tools.fth
...
  94 passed,    0 failed.
PForth Tests PASSED
```

... and on MSYS2/Cygwin:
```
Include t_tools.fth
    include added 1712 bytes,38292 left.
(got=-74, expected=0) INCORRECT RESULT: T{ 37. FID2 @ RESIZE-FILE -> 0 }T
(got=50, expected=37) INCORRECT RESULT: T{ FID2 @ FILE-SIZE -> 37. 0 }T
(got=50, expected=37) INCORRECT RESULT: T{ CBUF BUF 100 FID2 @ READ-FILE -> 37 0 }T
(got=-1, expected=0) INCORRECT RESULT: T{ PAD 38 BUF 38 S= -> FALSE }T
Include t_required_helper1.fth
    include added 0 bytes,37172 left.
Include t_required_helper1.fth
    include added 0 bytes,37172 left.
Include t_required_helper2.fth
    include added 0 bytes,37172 left.
Include t_required_helper2.fth
    include added 0 bytes,37172 left.
  90 passed,    4 failed.
make: *** [Makefile:165: test] Error 40
```