### PR TITLE
Zig for (cross) compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ On Unix and MacOS using Makefile:
     ./pforth_standalone
     
 For more details, see the [Wiki](https://github.com/philburk/pforth/wiki/Compiling-on-Unix)
+Please note that this can help with other platforms as well, see platforms/zig-crossbuild/ for an example.
 
 Using CMake:
 

--- a/platforms/zig-crossbuild/cross-compile.sh
+++ b/platforms/zig-crossbuild/cross-compile.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# example for crosscompiling
+# note-1: Please make sure zig is available on the path!
+# depending on the target you may need to set IO_SOURCE as well:
+#   target="x86_64-windows-gnu" IO_SOURCE="pf_fileio_stdio.c pf_io_win32.c" ./cross-compile.sh pforth
+# note-2: above compiles a Windows executable which may fail at runtime!
+
+if test -z "$target"
+then
+  # this builds a static executable with MUSL
+  target=x86_64-linux-musl
+fi
+
+CC="zig cc --target=$target" make -f ../unix/Makefile "$@"

--- a/platforms/zig-crossbuild/default.sh
+++ b/platforms/zig-crossbuild/default.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# note: Please make sure zig is available on the path!
+
+CC="zig cc" make -f ../unix/Makefile "$@"


### PR DESCRIPTION
Two short shell scripts showing how [Zig](https://ziglang.org/) can be used to (cross)compile PForth.

Technically this is not limited to Posix platforms.
Primary reason not to include Windows batch files as well is that Win32 builds seen to be a bit tricky at the moment.

Needs  #192 to be merged before this one.
