### PR TITLE
fix fallback/stdio build

### DIFF
--- a/csrc/stdio/pf_io_stdio.c
+++ b/csrc/stdio/pf_io_stdio.c
@@ -58,3 +58,7 @@ void sdTerminalTerm( void )
 {
 }
 
+cell_t sdSleepMillis(cell_t msec)
+{
+    return PF_ERR_NOT_SUPPORTED;
+}

--- a/platforms/unix/Makefile
+++ b/platforms/unix/Makefile
@@ -29,9 +29,10 @@ ifndef WIDTHOPT
   WIDTHOPT=
 endif
 ifndef IO_SOURCE
+  # for POSIX systems:
   IO_SOURCE = pf_io_posix.c pf_fileio_stdio.c
-  #IO_SOURCE = pf_io_stdio.c
-  #            TODO: add demo what else is needed for this to work
+  # for generic / any system supporting stdio:
+  #   IO_SOURCE = pf_io_stdio.c pf_fileio_stdio.c
 endif
 
 SRCDIR       = ../..


### PR DESCRIPTION
Fixes the build issue #195 on {MSYS2, Linux, FreeBSD, NetBSD}.

Test on Linux, FreeBSD are now ok:
```
$ IO_SOURCE="pf_io_stdio.c pf_fileio_stdio.c" make test
...
Standalone pForth executable written to pforth_standalone
cd ../../fth && /home/siggi/build/vanilla/pforth-2.0.1/platforms/unix/pforth_standalone -q t_corex.fth
...
 124 passed,    0 failed.
cd ../../fth && /home/siggi/build/vanilla/pforth-2.0.1/platforms/unix/pforth_standalone -q t_strings.fth
...
  58 passed,    0 failed.
cd ../../fth && /home/siggi/build/vanilla/pforth-2.0.1/platforms/unix/pforth_standalone -q t_locals.fth
...
   9 passed,    0 failed.
cd ../../fth && /home/siggi/build/vanilla/pforth-2.0.1/platforms/unix/pforth_standalone -q t_alloc.fth
...
   1 passed,    0 failed.
cd ../../fth && /home/siggi/build/vanilla/pforth-2.0.1/platforms/unix/pforth_standalone -q t_floats.fth
...
  60 passed,    0 failed.
cd ../../fth && /home/siggi/build/vanilla/pforth-2.0.1/platforms/unix/pforth_standalone -q t_file.fth
...
  94 passed,    0 failed.
PForth Tests PASSED
```

MSYS2 still fails on RESIZE-FILE.
Tests for FILE-RESIZE fails on NetBSD, which should probably be treated as separate issue.
