### PR TITLE
fixed RESIZE-FILE

### DIFF
--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -41,7 +41,8 @@ static bool_t TruncateFile( FileStream *File, long Newsize )
 {
 	bool_t Error = TRUE;
 	int fd;
-	if(  -1  !=  ( fd = fileno(File) )  ) {
+	if(  -1  !=  ( fd = fileno(File) )  )
+	{
 		if( 0 == ftruncate(fd, Newsize) )
 			Error = FALSE;
 	}

--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -28,7 +28,7 @@ typedef int bool_t;
 
 static bool_t TruncateFile( FileStream *File, long Newsize );  /* Shrink the file FILE to NEWSIZE.  Return non-FALSE on error. */
 
-#if defined( __CYGWIN__) || defined( __FreeBSD__) || defined(__NetBSD__)  /* __unix__ */
+#if defined( __CYGWIN__) || defined( __FreeBSD__) || defined(__NetBSD__)  || defined(__minix__) /* __unix__ */
 /*  Cygwin, FreeBSD, NetBSD and (Manjaro)Linux all define "__unix__", 
       which might also be defined on incompatible platforms as well (so we do not use it).
       Linux is excluded from the if statement in order to test the portable code on build.

--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -102,7 +102,7 @@ static bool_t TruncateFile( FileStream *File, long Newsize )
         {
             if( CopyFile( File, TmpFile, Newsize )) goto cleanup;
             if( fseek( TmpFile, 0, SEEK_SET ) != 0 ) goto cleanup;
-            if( freopen( getFilePathFromStream(File), "w+b", File ) == NULL ) goto cleanup;
+            if( freopen( NULL, "w+b", File ) == NULL ) goto cleanup;
             if( CopyFile( TmpFile, File, Newsize )) goto cleanup;
             Error = FALSE;
 

--- a/csrc/stdio/pf_fileio_stdio.c
+++ b/csrc/stdio/pf_fileio_stdio.c
@@ -28,10 +28,11 @@ typedef int bool_t;
 
 static bool_t TruncateFile( FileStream *File, long Newsize );  /* Shrink the file FILE to NEWSIZE.  Return non-FALSE on error. */
 
-#if defined( __CYGWIN__) || defined( __FreeBSD__) || defined(__NetBSD__) || defined(__linux__)  /* __unix__ */
+#if defined( __CYGWIN__) || defined( __FreeBSD__) || defined(__NetBSD__)  /* __unix__ */
 /*  Cygwin, FreeBSD, NetBSD and (Manjaro)Linux all define "__unix__", 
       which might also be defined on incompatible platforms as well (so we do not use it).
-	This uses Unix specific APIs to work around problems with the portable implementation.
+      Linux is excluded from the if statement in order to test the portable code on build.
+    This uses Unix specific APIs to work around problems with the portable implementation.
 */
 
 #include<stdio.h>   /* fileno()  */

--- a/platforms/unix/Makefile
+++ b/platforms/unix/Makefile
@@ -31,8 +31,8 @@ endif
 ifndef IO_SOURCE
   # for POSIX systems:
   IO_SOURCE = pf_io_posix.c pf_fileio_stdio.c
-  # for generic / any system supporting stdio:
-  #   IO_SOURCE = pf_io_stdio.c pf_fileio_stdio.c
+  #IO_SOURCE = pf_io_stdio.c
+  #            TODO: add demo what else is needed for this to work
 endif
 
 SRCDIR       = ../..

--- a/platforms/unix/Makefile
+++ b/platforms/unix/Makefile
@@ -29,9 +29,10 @@ ifndef WIDTHOPT
   WIDTHOPT=
 endif
 ifndef IO_SOURCE
+  # for POSIX systems:
   IO_SOURCE = pf_io_posix.c pf_fileio_stdio.c
-  #IO_SOURCE = pf_io_stdio.c
-  #            TODO: add demo what else is needed for this to work
+  # for generic / any system supporting stdio:
+  #   IO_SOURCE = pf_io_stdio.c pf_fileio_stdio.c
 endif
 
 SRCDIR       = ../..

--- a/platforms/unix/Makefile
+++ b/platforms/unix/Makefile
@@ -29,7 +29,6 @@ ifndef WIDTHOPT
   WIDTHOPT=
 endif
 ifndef IO_SOURCE
-  # for POSIX systems:
   IO_SOURCE = pf_io_posix.c pf_fileio_stdio.c
   #IO_SOURCE = pf_io_stdio.c
   #            TODO: add demo what else is needed for this to work


### PR DESCRIPTION
This fixes #189 .

Since we were already through the looking glass anyway (by putting NetBSD specific code into /csrc/stdio/pf_fileio_stdio.c) 
and Cygwin stil did not work, the cleaner solution was to implement TruncateFile via Unix-API.

This was tested (make clean test) on Cygwin/MSYS2, FreeBSD, NetBSD, Linux/Manjaro.

