### PR TITLE
fix floating point output 

### DIFF
--- a/fth/floats.fth
+++ b/fth/floats.fth
@@ -23,22 +23,6 @@
 
 ANEW TASK-FLOATS.FTH
 
-: debug-flog
-  fdup fdup f0< F0= or
-  if
-    ." ------> invalid parameter in debug-flog: " 
-    fdup f0=
-    if
-      ." x is zero!"
-    else
-      ." negative x!"
-    then
-	cr
-  else
-    flog
-  then
-;
-
 : safe-flog
   fdup fdup f0< F0= or not
   if
@@ -160,7 +144,7 @@ fvariable FVAR-REP  \ scratch var for represent
         0 -> n
     ELSE
         fvar-rep f@
-        debug-flog
+        safe-flog
         fdup f0< not
         IF
             1 s>f f+ \ round up exponent
@@ -349,7 +333,7 @@ variable FP-OUTPUT-PTR            \ points into FP-OUTPUT-PAD
 : (F.)  ( F: r -- , normal or scientific ) { | n n3 ndiff prec' -- }
     fp-output-pad fp-output-ptr !  \ setup pointer
     fp-represent-pad  \ place to put number
-    fdup debug-flog 1 s>f f+ f>s precision max
+    fdup safe-flog 1 s>f f+ f>s precision max
     fp_precision_max min dup -> prec'
     represent
     ( -- n flag1 flag2 )

--- a/fth/floats.fth
+++ b/fth/floats.fth
@@ -23,6 +23,29 @@
 
 ANEW TASK-FLOATS.FTH
 
+: debug-flog
+  fdup fdup f0< F0= or
+  if
+    ." ------> invalid parameter in debug-flog: " 
+    fdup f0=
+    if
+      ." x is zero!"
+    else
+      ." negative x!"
+    then
+	cr
+  else
+    flog
+  then
+;
+
+: safe-flog
+  fdup fdup f0< F0= or not
+  if
+    flog
+  then
+;
+
 : FALIGNED  ( addr -- a-addr )
     1 floats 1- +
     1 floats /
@@ -137,7 +160,7 @@ fvariable FVAR-REP  \ scratch var for represent
         0 -> n
     ELSE
         fvar-rep f@
-        flog
+        debug-flog
         fdup f0< not
         IF
             1 s>f f+ \ round up exponent
@@ -326,7 +349,7 @@ variable FP-OUTPUT-PTR            \ points into FP-OUTPUT-PAD
 : (F.)  ( F: r -- , normal or scientific ) { | n n3 ndiff prec' -- }
     fp-output-pad fp-output-ptr !  \ setup pointer
     fp-represent-pad  \ place to put number
-    fdup flog 1 s>f f+ f>s precision max
+    fdup debug-flog 1 s>f f+ f>s precision max
     fp_precision_max min dup -> prec'
     represent
     ( -- n flag1 flag2 )


### PR DESCRIPTION
Calls to FLOG in floats.h are redirected to a custom function, which simply leaves invalid parameters on the stack instead of trying to consume them.

Fixes #199
Here's the new output from OpenWatcomC on FreeDos:
![fixed](https://github.com/user-attachments/assets/f619443b-97c2-41a8-8e3d-4d7dfac784ca)

Output on other platforms is unaffected (here's the MSYS2/Cygwin version):
```
cd ../../fth && /d/arbeit/src/contrib/pforth/platforms/unix/pforth_standalone -q t_floats.fth
Include t_tools.fth
    include added 1712 bytes,38292 left.
T_F. T.SERIES final = 1.234533e+17
T_F. T.SERIES final = 1.234533e+17
T_F. T.SERIES final = 9.303299e+20
T_F>D T.SERIES final = 1.175126e+17
T_FS. T.SERIES final = 1.081004e+16
T_FS. T.SERIES final = 6.448631e-18
T_FE. T.SERIES final = 1.601179e+17
T_FE. T.SERIES final = 1.219607e-18
T_FE. T.SERIES final = 1.019165e+23
T_FE. T.SERIES final = 2.103802e-12
  60 passed,    0 failed.
  ```
  