### PR TITLE
change <sys/poll.h> to POSIX standard <poll.h> in pf_io_posix.c

### DIFF
--- a/csrc/posix/pf_io_posix.c
+++ b/csrc/posix/pf_io_posix.c
@@ -34,7 +34,7 @@
 #include <sys/int_types.h> /* Needed on Solaris for uint32_t in termio.h */
 #endif
 #include <termios.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 static struct termios save_termios;
 static int stdin_is_tty;


### PR DESCRIPTION
#include <poll.h> is the posix standard and more portable than #include <sys/poll.h>. <sys/poll.h> leads to compiler errors on linux and likely other systems.